### PR TITLE
SONARGO-34  Update dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,7 @@ ws_scan_task:
   depends_on:
     - build
   # run only on master, long-term branches and mend-related branches
-  #only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "mend-.*")
+  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "mend-.*")
   env:
     WS_APIKEY: VAULT[development/kv/data/mend data.apikey]
     GOPATH: ${HOME}/go

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,7 @@ ws_scan_task:
   depends_on:
     - build
   # run only on master, long-term branches and mend-related branches
-  only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "mend-.*")
+  #only_if: $CIRRUS_USER_COLLABORATOR == 'true' && ($CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "mend-.*")
   env:
     WS_APIKEY: VAULT[development/kv/data/mend data.apikey]
     GOPATH: ${HOME}/go

--- a/build.gradle
+++ b/build.gradle
@@ -30,14 +30,16 @@ allprojects {
 
     ext {
         buildNumber = System.getProperty("buildNumber")
-        slangDependenciesVersion = '1.15.2.6150'
-        analyzerCommonsVersion = '2.7.0.1482'
-        pluginApiVersion = '10.1.0.809'
+
+         slangDependenciesVersion = '1.16.0.6202'
+         analyzerCommonsVersion = '2.13.0.3004'
+         pluginApiVersion = '10.10.0.2391'
+         sonarqubeVersion = '10.0.0.68432'
+         orchestratorVersion = '3.42.0.312'
+         sonarlintVersion = '9.0.0.74282'
         // slf4j is provided by SQ, SC or SL, should be aligned with sonar-plugin-api
-        slf4jApiVersion = '1.7.30'
-        sonarqubeVersion = '10.0.0.68432'
-        orchestratorVersion = '3.42.0.312'
-        sonarlintVersion = '9.0.0.74282'
+         slf4jApiVersion = '1.7.30'
+
         sonarLinksCi = 'https://cirrus-ci.com/github/SonarSource/sonar-go'
         sonarLinksScm = 'https://github.com/SonarSource/sonar-go'
 
@@ -81,32 +83,34 @@ subprojects {
             dependency "org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures:${pluginApiVersion}"
             dependency "org.sonarsource.sonarqube:sonar-plugin-api-impl:${sonarqubeVersion}"
             dependency "org.slf4j:slf4j-api:${slf4jApiVersion}"
-            dependency "ch.qos.logback:logback-classic:1.2.9"
             dependency "org.sonarsource.sonarqube:sonar-ws:${sonarqubeVersion}"
-            dependency 'com.google.code.findbugs:jsr305:3.0.2'
-            dependency 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
-            dependency "org.junit.jupiter:junit-jupiter-api:5.10.0"
-            dependency "org.junit.jupiter:junit-jupiter-engine:5.10.0"
-            dependency 'junit:junit:4.13.2'
-            dependency 'org.mockito:mockito-core:5.5.0'
-            dependency 'org.assertj:assertj-core:3.24.2'
-            dependency 'io.github.classgraph:classgraph:4.8.162'
             dependency "org.sonarsource.analyzer-commons:sonar-analyzer-test-commons:${analyzerCommonsVersion}"
             dependency "org.sonarsource.analyzer-commons:sonar-analyzer-commons:${analyzerCommonsVersion}"
             dependency "org.sonarsource.analyzer-commons:sonar-xml-parsing:${analyzerCommonsVersion}"
             dependency "org.sonarsource.orchestrator:sonar-orchestrator:${orchestratorVersion}"
             dependency "org.sonarsource.sonarlint.core:sonarlint-core:${sonarlintVersion}"
-            dependency "javax.annotation:javax.annotation-api:1.3.2"
             dependency "org.sonarsource.slang:slang-api:${slangDependenciesVersion}"
             dependency "org.sonarsource.slang:slang-testing:${slangDependenciesVersion}"
             dependency "org.sonarsource.slang:slang-antlr:${slangDependenciesVersion}"
             dependency "org.sonarsource.slang:slang-checks:${slangDependenciesVersion}"
             dependency "org.sonarsource.slang:slang-plugin:${slangDependenciesVersion}"
             dependency "org.sonarsource.slang:checkstyle-import:${slangDependenciesVersion}"
+
+            dependency 'junit:junit:4.13.2'
+            dependency 'org.mockito:mockito-core:5.13.0'
+            dependency 'org.assertj:assertj-core:3.26.3'
+            dependency "ch.qos.logback:logback-classic:1.2.13"
+            dependency "org.junit.jupiter:junit-jupiter-api:5.11.0"
+            dependency "org.junit.jupiter:junit-jupiter-engine:5.11.0"
+
+            dependency 'com.google.code.findbugs:jsr305:3.0.2'
+            dependency 'io.github.classgraph:classgraph:4.8.162'
+            dependency "javax.annotation:javax.annotation-api:1.3.2"
+            dependency 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
         }
     }
 
-    java.sourceCompatibility = JavaVersion.VERSION_11
+    java.sourceCompatibility = JavaVersion.VERSION_17
     tasks.withType(JavaCompile) {
         options.encoding = "UTF-8"
         options.release = java.sourceCompatibility.majorVersion as int

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'com.jfrog.artifactory' version '4.28.2'
-    id 'io.spring.dependency-management' version '1.0.6.RELEASE' apply false
     id 'org.sonarqube' version '3.5.0.2730'
     id 'de.thetaphi.forbiddenapis' version '3.0' apply false
     id 'com.diffplug.spotless' version '6.15.0'
@@ -13,7 +12,6 @@ plugins {
 allprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    apply plugin: 'io.spring.dependency-management'
     apply plugin: 'com.jfrog.artifactory'
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
@@ -30,15 +28,6 @@ allprojects {
 
     ext {
         buildNumber = System.getProperty("buildNumber")
-
-         slangDependenciesVersion = '1.16.0.6202'
-         analyzerCommonsVersion = '2.13.0.3004'
-         pluginApiVersion = '10.10.0.2391'
-         sonarqubeVersion = '10.0.0.68432'
-         orchestratorVersion = '3.42.0.312'
-         sonarlintVersion = '9.0.0.74282'
-        // slf4j is provided by SQ, SC or SL, should be aligned with sonar-plugin-api
-         slf4jApiVersion = '1.7.30'
 
         sonarLinksCi = 'https://cirrus-ci.com/github/SonarSource/sonar-go'
         sonarLinksScm = 'https://github.com/SonarSource/sonar-go'
@@ -75,40 +64,7 @@ subprojects {
     // do not publish to Artifactory by default
     artifactoryPublish.skip = true
 
-    apply plugin: 'io.spring.dependency-management'
     apply plugin: 'com.diffplug.spotless'
-    dependencyManagement {
-        dependencies {
-            dependency "org.sonarsource.api.plugin:sonar-plugin-api:${pluginApiVersion}"
-            dependency "org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures:${pluginApiVersion}"
-            dependency "org.sonarsource.sonarqube:sonar-plugin-api-impl:${sonarqubeVersion}"
-            dependency "org.slf4j:slf4j-api:${slf4jApiVersion}"
-            dependency "org.sonarsource.sonarqube:sonar-ws:${sonarqubeVersion}"
-            dependency "org.sonarsource.analyzer-commons:sonar-analyzer-test-commons:${analyzerCommonsVersion}"
-            dependency "org.sonarsource.analyzer-commons:sonar-analyzer-commons:${analyzerCommonsVersion}"
-            dependency "org.sonarsource.analyzer-commons:sonar-xml-parsing:${analyzerCommonsVersion}"
-            dependency "org.sonarsource.orchestrator:sonar-orchestrator:${orchestratorVersion}"
-            dependency "org.sonarsource.sonarlint.core:sonarlint-core:${sonarlintVersion}"
-            dependency "org.sonarsource.slang:slang-api:${slangDependenciesVersion}"
-            dependency "org.sonarsource.slang:slang-testing:${slangDependenciesVersion}"
-            dependency "org.sonarsource.slang:slang-antlr:${slangDependenciesVersion}"
-            dependency "org.sonarsource.slang:slang-checks:${slangDependenciesVersion}"
-            dependency "org.sonarsource.slang:slang-plugin:${slangDependenciesVersion}"
-            dependency "org.sonarsource.slang:checkstyle-import:${slangDependenciesVersion}"
-
-            dependency 'junit:junit:4.13.2'
-            dependency 'org.mockito:mockito-core:5.13.0'
-            dependency 'org.assertj:assertj-core:3.26.3'
-            dependency "ch.qos.logback:logback-classic:1.2.13"
-            dependency "org.junit.jupiter:junit-jupiter-api:5.11.0"
-            dependency "org.junit.jupiter:junit-jupiter-engine:5.11.0"
-
-            dependency 'com.google.code.findbugs:jsr305:3.0.2'
-            dependency 'io.github.classgraph:classgraph:4.8.162'
-            dependency "javax.annotation:javax.annotation-api:1.3.2"
-            dependency 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
-        }
-    }
 
     java.sourceCompatibility = JavaVersion.VERSION_17
     tasks.withType(JavaCompile) {

--- a/its/plugin/build.gradle
+++ b/its/plugin/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-    testImplementation 'org.sonarsource.sonarlint.core:sonarlint-core'
-    testImplementation 'org.sonarsource.orchestrator:sonar-orchestrator'
-    testImplementation 'org.assertj:assertj-core'
-    testImplementation 'org.sonarsource.sonarqube:sonar-ws'
-    testImplementation 'org.sonarsource.analyzer-commons:sonar-analyzer-commons'
+    testImplementation libs.sonar.analyzer.commons
+    testImplementation testLibs.sonar.ws
+    testImplementation testLibs.assertj.core
+    testImplementation testLibs.sonarlint.core
+    testImplementation testLibs.sonar.orchestrator
 }
 
 sonarqube.skipProject = true

--- a/its/ruling/build.gradle
+++ b/its/ruling/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-    testImplementation 'org.sonarsource.orchestrator:sonar-orchestrator'
-    testImplementation 'org.assertj:assertj-core'
-    testImplementation 'org.sonarsource.analyzer-commons:sonar-analyzer-commons'
+    testImplementation libs.sonar.analyzer.commons
+    testImplementation testLibs.assertj.core
+    testImplementation testLibs.sonar.orchestrator
 }
 
 sonarqube.skipProject = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    def slangDependenciesVersion = '1.16.0.6211'
+    def slangDependenciesVersion = '1.16.0.6221'
     def analyzerCommonsVersion = '2.13.0.3004'
     def pluginApiVersion = '10.10.0.2391'
     def sonarqubeVersion = '10.0.0.68432'

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    def slangDependenciesVersion = '1.16.0.6202'
+    def slangDependenciesVersion = '1.16.0.6211'
     def analyzerCommonsVersion = '2.13.0.3004'
     def pluginApiVersion = '10.10.0.2391'
     def sonarqubeVersion = '10.0.0.68432'

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,6 @@ dependencyResolutionManagement {
             library("slang-plugin", "org.sonarsource.slang", "slang-plugin").version(slangDependenciesVersion)
             library("checkstyle-import", "org.sonarsource.slang", "checkstyle-import").version(slangDependenciesVersion)
             library("slf4j-api", "org.slf4j", "slf4j-api").version(slf4jApiVersion)
-
             library("minimal-json", "com.eclipsesource.minimal-json", "minimal-json").version("0.9.5")
         }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,8 +37,6 @@ dependencyResolutionManagement {
             library("sonar-ws", "org.sonarsource.sonarqube", "sonar-ws").version(sonarqubeVersion)
             library("slang-antlr", "org.sonarsource.slang", "slang-antlr").version(slangDependenciesVersion)
             library("slang-testing", "org.sonarsource.slang", "slang-testing").version(slangDependenciesVersion)
-            library("junit", "junit", "junit").version("4.13.2")
-            library("awaitility", "org.awaitility", "awaitility").version("4.2.1")
             library("mockito-core", "org.mockito", "mockito-core").version("5.13.0")
             library("assertj-core", "org.assertj", "assertj-core").version("3.26.3")
             library("classgraph", "io.github.classgraph", "classgraph").version("0.9.5")

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,49 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    def slangDependenciesVersion = '1.16.0.6202'
+    def analyzerCommonsVersion = '2.13.0.3004'
+    def pluginApiVersion = '10.10.0.2391'
+    def sonarqubeVersion = '10.0.0.68432'
+    def orchestratorVersion = '3.42.0.312'
+    def sonarlintVersion = '9.0.0.74282'
+    // slf4j is provided by SQ, SC or SL, should be aligned with sonar-plugin-api
+    def slf4jApiVersion = '1.7.30'
+
+    versionCatalogs {
+        libs {
+            library("sonar-plugin-api", "org.sonarsource.api.plugin", "sonar-plugin-api").version(pluginApiVersion)
+            library("sonar-xml-parsing", "org.sonarsource.analyzer-commons", "sonar-xml-parsing").version(analyzerCommonsVersion)
+            library("sonar-analyzer-commons", "org.sonarsource.analyzer-commons", "sonar-analyzer-commons").version(analyzerCommonsVersion)
+            library("slang-api", "org.sonarsource.slang", "slang-api").version(slangDependenciesVersion)
+            library("slang-checks", "org.sonarsource.slang", "slang-checks").version(slangDependenciesVersion)
+            library("slang-plugin", "org.sonarsource.slang", "slang-plugin").version(slangDependenciesVersion)
+            library("checkstyle-import", "org.sonarsource.slang", "checkstyle-import").version(slangDependenciesVersion)
+            library("slf4j-api", "org.slf4j", "slf4j-api").version(slf4jApiVersion)
+
+            library("minimal-json", "com.eclipsesource.minimal-json", "minimal-json").version("0.9.5")
+        }
+
+        testLibs {
+            library("sonar-plugin-api-test-fixtures", "org.sonarsource.api.plugin", "sonar-plugin-api-test-fixtures").version(pluginApiVersion)
+            library("sonar-plugin-api-impl", "org.sonarsource.sonarqube", "sonar-plugin-api-impl").version(sonarqubeVersion)
+            library("sonar-orchestrator", "org.sonarsource.orchestrator", "sonar-orchestrator").version(orchestratorVersion)
+            library("sonarlint-core", "org.sonarsource.sonarlint.core", "sonarlint-core").version(sonarlintVersion)
+            library("sonar-ws", "org.sonarsource.sonarqube", "sonar-ws").version(sonarqubeVersion)
+            library("slang-antlr", "org.sonarsource.slang", "slang-antlr").version(slangDependenciesVersion)
+            library("slang-testing", "org.sonarsource.slang", "slang-testing").version(slangDependenciesVersion)
+            library("junit", "junit", "junit").version("4.13.2")
+            library("awaitility", "org.awaitility", "awaitility").version("4.2.1")
+            library("mockito-core", "org.mockito", "mockito-core").version("5.13.0")
+            library("assertj-core", "org.assertj", "assertj-core").version("3.26.3")
+            library("classgraph", "io.github.classgraph", "classgraph").version("0.9.5")
+            library("junit-jupiter-api", "org.junit.jupiter", "junit-jupiter-api").version("5.11.0")
+            library("junit-jupiter-engine", "org.junit.jupiter", "junit-jupiter-engine").version("5.11.0")
+        }
+    }
+}
+
 rootProject.name = 'sonar-go'
 
 include 'sonar-go-to-slang'

--- a/sonar-go-plugin/build.gradle
+++ b/sonar-go-plugin/build.gradle
@@ -10,9 +10,7 @@ dependencies {
     compileOnly libs.sonar.plugin.api
 
     implementation libs.sonar.analyzer.commons
-    implementation  (libs.slang.plugin) {
-        exclude(group: 'org.assertj', module: 'assertj-core')
-    }
+    implementation  (libs.slang.plugin)
     implementation libs.slang.checks
     implementation libs.slang.api
     implementation libs.checkstyle.import

--- a/sonar-go-plugin/build.gradle
+++ b/sonar-go-plugin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.0'
 }
 
 // require sonar-go-to-slang binaries to be build

--- a/sonar-go-plugin/build.gradle
+++ b/sonar-go-plugin/build.gradle
@@ -10,7 +10,9 @@ dependencies {
     compileOnly libs.sonar.plugin.api
 
     implementation libs.sonar.analyzer.commons
-    implementation libs.slang.plugin
+    implementation  (libs.slang.plugin) {
+        exclude(group: 'org.assertj', module: 'assertj-core')
+    }
     implementation libs.slang.checks
     implementation libs.slang.api
     implementation libs.checkstyle.import
@@ -87,7 +89,7 @@ shadowJar {
         exclude 'tmp/**'
     }
     doLast {
-        enforceJarSizeAndCheckContent(shadowJar.archiveFile.get().asFile, 12_000_000L, 13_500_000L)
+        enforceJarSizeAndCheckContent(shadowJar.archiveFile.get().asFile, 8_000_000L, 8_500_000L)
     }
 }
 

--- a/sonar-go-plugin/build.gradle
+++ b/sonar-go-plugin/build.gradle
@@ -7,25 +7,28 @@ shadowJar.dependsOn ':sonar-go-to-slang:build'
 test.dependsOn ':sonar-go-to-slang:build'
 
 dependencies {
-    implementation 'org.sonarsource.slang:slang-api'
-    implementation 'org.sonarsource.slang:slang-checks'
-    implementation 'org.sonarsource.slang:slang-plugin'
-    implementation 'org.sonarsource.slang:checkstyle-import'
+    compileOnly libs.sonar.plugin.api
+
+    implementation libs.sonar.analyzer.commons
+    implementation libs.slang.plugin
+    implementation libs.slang.checks
+    implementation libs.slang.api
+    implementation libs.checkstyle.import
     // dependency on sonar-go-to-slang binaries
+    implementation libs.minimal.json
+
     runtimeOnly files(project(':sonar-go-to-slang').buildDir)
-    compileOnly 'org.sonarsource.api.plugin:sonar-plugin-api'
-    testImplementation 'org.sonarsource.sonarqube:sonar-plugin-api-impl'
-    testImplementation 'org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures'
-    implementation 'org.sonarsource.analyzer-commons:sonar-analyzer-commons'
-    implementation 'com.eclipsesource.minimal-json:minimal-json'
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
-    testImplementation 'org.assertj:assertj-core'
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'io.github.classgraph:classgraph'
-    testImplementation 'org.sonarsource.slang:slang-antlr'
-    testImplementation 'org.sonarsource.slang:slang-testing'
-    testImplementation 'org.awaitility:awaitility:3.1.0'
+
+    testImplementation testLibs.slang.antlr
+    testImplementation testLibs.assertj.core
+    testImplementation testLibs.mockito.core
+    testImplementation testLibs.classgraph
+    testImplementation testLibs.slang.testing
+    testImplementation testLibs.junit.jupiter.api
+    testImplementation testLibs.sonar.plugin.api.impl
+    testImplementation testLibs.sonar.plugin.api.test.fixtures
+
+    testRuntimeOnly testLibs.junit.jupiter.engine
 }
 
 tasks.withType(JavaCompile) {

--- a/sonar-go-plugin/build.gradle
+++ b/sonar-go-plugin/build.gradle
@@ -87,7 +87,7 @@ shadowJar {
         exclude 'tmp/**'
     }
     doLast {
-        enforceJarSizeAndCheckContent(shadowJar.archiveFile.get().asFile, 7_800_000L, 8_400_000L)
+        enforceJarSizeAndCheckContent(shadowJar.archiveFile.get().asFile, 12_000_000L, 13_500_000L)
     }
 }
 

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoSensor.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoSensor.java
@@ -53,7 +53,6 @@ public class GoSensor extends SlangSensor {
   public void describe(SensorDescriptor descriptor) {
     descriptor.onlyOnLanguage(GoLanguage.KEY)
       .name("Code Quality and Security for Go");
-    processesFilesIndependently(descriptor);
   }
 
   @Override


### PR DESCRIPTION
Don't merge before releasing slang-enterprise with the changes from [SONARSLANG-671 ](https://github.com/SonarSource/slang-enterprise/pull/540/files)
Then update the slangVersion