### PR TITLE
SONARGO-75 Use Gradle modules with enabled build cache

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,4 @@
 [submodule "build-logic"]
 	path = build-logic
 	url = https://github.com/SonarSource/cloud-native-gradle-modules
+	branch = SONARGO-75


### PR DESCRIPTION
[SONARGO-75](https://sonarsource.atlassian.net/browse/SONARGO-75)



[SONARGO-75]: https://sonarsource.atlassian.net/browse/SONARGO-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ