### PR TITLE
SONARGO-103 Scan Go dependencies by Mend

### DIFF
--- a/.cirrus/modules/build.star
+++ b/.cirrus/modules/build.star
@@ -90,8 +90,7 @@ def whitesource_script():
 def sca_scan_task():
     return {
         "sca_scan_task": {
-            # TODO uncomment before merge
-            # "only_if": is_main_branch(),
+            "only_if": is_main_branch(),
             "depends_on": "build",
             "env": whitesource_api_env(),
             "eks_container": custom_image_container_builder(dockerfile="Dockerfile", cpu=1, memory="4G"),

--- a/.cirrus/modules/build.star
+++ b/.cirrus/modules/build.star
@@ -90,10 +90,11 @@ def whitesource_script():
 def sca_scan_task():
     return {
         "sca_scan_task": {
-            "only_if": is_main_branch(),
+            # TODO uncomment before merge
+            # "only_if": is_main_branch(),
             "depends_on": "build",
             "env": whitesource_api_env(),
-            "eks_container": base_image_container_builder(cpu=1, memory="4G"),
+            "eks_container": custom_image_container_builder(dockerfile="Dockerfile", cpu=1, memory="4G"),
             "gradle_cache": gradle_cache(),
             "gradle_wrapper_cache": gradle_wrapper_cache(),
             "project_version_cache": project_version_cache(),


### PR DESCRIPTION
[SONARGO-103](https://sonarsource.atlassian.net/browse/SONARGO-103)

The Dockerk image used in sca_scan_task needs to contain Go installed, otherwise Mend is not able to resolve Go dependencies



[SONARGO-103]: https://sonarsource.atlassian.net/browse/SONARGO-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ