### PR TITLE
SONARGO-120 Fix Gradle task dependencies

### DIFF
--- a/sonar-go-to-slang/build.gradle.kts
+++ b/sonar-go-to-slang/build.gradle.kts
@@ -70,6 +70,7 @@ if (isCi) {
         inputs.files(
             fileTree(projectDir).matching {
                 include("*.go")
+                exclude("*_generated.go")
             }
         )
         outputs.files(reportPath)


### PR DESCRIPTION
`goLangCiLint` uses implicitly result of `compileGo` (the file `goparser_generated.go`), which is forbidden my Gradle. As this file is generated, we don't need to lint it, so I removed it from the linter's scope

[SONARGO-120](https://sonarsource.atlassian.net/browse/SONARGO-120)



[SONARGO-120]: https://sonarsource.atlassian.net/browse/SONARGO-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ