### PR TITLE
chore: use the renamed sonar.sca.exclusions property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ sonar {
         property("sonar.links.issue", "https://jira.sonarsource.com/browse/SONARGO")
         property("sonar.exclusions", "**/build/**/*")
         property(
-            "sonar.sca.excludedManifests",
+            "sonar.sca.exclusions",
             "private/its/**,go/**,private/go-custom-rules-plugin/**"
         )
     }


### PR DESCRIPTION
`sonar.sca.excludedManifests` is deprecated in SQS 2025.3 and is replaced with `sonar.sca.exlusions`. The behavior is exactly the same, this is just a rename to better match other sonar properties.